### PR TITLE
Put single quotes around encoding attribute value

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 /*.iml
 /*.ipr
 /*.iws
+.idea/
 
 # Ignore the generated json file
 /metadata.json

--- a/providers/database.rb
+++ b/providers/database.rb
@@ -24,7 +24,7 @@ notifying_action :create do
 
   command = "CREATE DATABASE \"#{new_resource.database}\""
   command << " TEMPLATE = #{new_resource.template}" if new_resource.template
-  command << " ENCODING = #{new_resource.encoding}"
+  command << " ENCODING = '#{new_resource.encoding}'"
   command << " TABLESPACE = #{new_resource.tablespace}" if new_resource.tablespace
   command << " LC_CTYPE = '#{new_resource.collation}' LC_COLLATE = '#{new_resource.collation}'" if new_resource.collation
   command << " CONNECTION LIMIT = #{new_resource.connection_limit}" if new_resource.connection_limit


### PR DESCRIPTION
When I attempted to use `psql_database` with an `encoding` value, I got an SQL syntax error.

Resource:

```ruby
psql_database 'bitbucket' do
  admin_username 'postgres'
  host 'localhost'
  owner 'bitbucketuser'
  connection_limit '-1'
  encoding 'UTF8'
end
```

Error during chef run:

```
           bash[psql bitbucket] (/tmp/kitchen/cache/cookbooks/psql/providers/database.rb line 35) had an error: Mixlib::ShellOut::ShellCommandFailed: Expected process to exit with [0], but received '1'
           ---- Begin output of "bash"  "/tmp/chef-script20170412-24267-frdoia" ----
           STDOUT: 
           STDERR: ERROR:  syntax error at or near "UTF8"
           LINE 1: CREATE DATABASE "bitbucket" ENCODING = UTF8 CONNECTION LIMIT...
                                                   ^
           ---- End output of "bash"  "/tmp/chef-script20170412-24267-frdoia" ----
           Ran "bash"  "/tmp/chef-script20170412-24267-frdoia" returned 1
```

Postgres expects the encoding to be wrapped in single quotes, so I added that to the `psql_database` provider.