### PR TITLE
remove cutlery dependency, its no longer necessary and does not work …

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -18,6 +18,6 @@ maintainer_email 'peter@realityforge.org'
 license          'Apache 2.0'
 description      'A set of LWRPs for interacting with postgres using the CLI.'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '0.3.0'
+version          '0.3.1'
 
-depends 'cutlery', '~> 0.1'
+# depends 'cutlery', '~> 0.1'

--- a/providers/database.rb
+++ b/providers/database.rb
@@ -14,7 +14,9 @@
 # limitations under the License.
 #
 
-notifying_action :create do
+use_inline_resources
+
+action :create do
   options = {}
   options[:host] = new_resource.host
   options[:port] = new_resource.port
@@ -41,7 +43,7 @@ notifying_action :create do
   end
 end
 
-notifying_action :owner do
+action :owner do
   options = {}
   options[:host] = new_resource.host
   options[:port] = new_resource.port
@@ -59,7 +61,7 @@ notifying_action :owner do
   end
 end
 
-notifying_action :drop do
+action :drop do
   options = {}
   options[:host] = new_resource.host
   options[:port] = new_resource.port

--- a/providers/exec.rb
+++ b/providers/exec.rb
@@ -14,7 +14,9 @@
 # limitations under the License.
 #
 
-notifying_action :run do
+use_inline_resources
+
+action :run do
   options = {}
   options[:host] = new_resource.host
   options[:port] = new_resource.port

--- a/providers/exec_file.rb
+++ b/providers/exec_file.rb
@@ -11,8 +11,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+use_inline_resources
 
-notifying_action :run do
+action :run do
   options = {}
   options[:host] = new_resource.host
   options[:port] = new_resource.port

--- a/providers/permission.rb
+++ b/providers/permission.rb
@@ -14,7 +14,9 @@
 # limitations under the License.
 #
 
-notifying_action :grant do
+use_inline_resources
+
+action :grant do
   options = {}
   options[:host] = new_resource.host
   options[:port] = new_resource.port
@@ -32,7 +34,7 @@ notifying_action :grant do
   end
 end
 
-notifying_action :revoke do
+action :revoke do
   options = {}
   options[:host] = new_resource.host
   options[:port] = new_resource.port

--- a/providers/schema.rb
+++ b/providers/schema.rb
@@ -12,7 +12,9 @@
 # limitations under the License.
 #
 
-notifying_action :grant_usage do
+use_inline_resources
+
+action :grant_usage do
   options = {}
   options[:host] = new_resource.host
   options[:port] = new_resource.port

--- a/providers/user.rb
+++ b/providers/user.rb
@@ -14,7 +14,9 @@
 # limitations under the License.
 #
 
-notifying_action :create do
+use_inline_resources
+
+action :create do
   options = {}
   options[:host] = new_resource.host
   options[:port] = new_resource.port
@@ -34,7 +36,7 @@ notifying_action :create do
   end
 end
 
-notifying_action :drop do
+action :drop do
   options = {}
   options[:host] = new_resource.host
   options[:port] = new_resource.port


### PR DESCRIPTION
…with chef v12 or v13

replaced notifying_action with use_inline_resources as indicated here: https://github.com/realityforge/chef-cutlery/commit/bd902bc570f2883d4c9059fbc2f1c34c55b73c83

notifying_action was the only reason for cutlery

cutlery is broken by this dependency: https://github.com/realityforge/chef-cutlery/blob/master/metadata.rb#L23

partial_search has been deprecated: https://docs.chef.io/chef_search.html , https://github.com/sethvargo/chef-api/issues/28, https://supermarket.chef.io/cookbooks/partial_search